### PR TITLE
[Feature]  API-REST - TP 3

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -89,10 +89,17 @@ if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
 }
 
 $MAVEN_WRAPPER_DISTS = $null
-if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+# DirectoryInfo.Target is only populated for symlinks/junctions; on a normal directory it is $null.
+# Indexing `[0]` can throw "Cannot index into a null array." on some PowerShell versions.
+$m2Item = Get-Item $MAVEN_M2_PATH
+$m2Target0 = $null
+if ($m2Item.PSObject.Properties.Match('Target').Count -gt 0) {
+  $m2Target0 = $m2Item.Target | Select-Object -First 1
+}
+if ($null -eq $m2Target0) {
   $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
 } else {
-  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+  $MAVEN_WRAPPER_DISTS = $m2Target0 + "/wrapper/dists"
 }
 
 $MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,26 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>

--- a/src/main/java/com/example/desabackend/DesaBackendApplication.java
+++ b/src/main/java/com/example/desabackend/DesaBackendApplication.java
@@ -3,6 +3,9 @@ package com.example.desabackend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Spring Boot entry point for the XploreNow backend (TP).
+ */
 @SpringBootApplication
 public class DesaBackendApplication {
 

--- a/src/main/java/com/example/desabackend/controller/ActivityController.java
+++ b/src/main/java/com/example/desabackend/controller/ActivityController.java
@@ -1,0 +1,99 @@
+package com.example.desabackend.controller;
+
+import com.example.desabackend.dto.ActivityDetailDto;
+import com.example.desabackend.dto.ActivitySummaryDto;
+import com.example.desabackend.dto.PageResponse;
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.service.ActivityCatalogService;
+import com.example.desabackend.service.RecommendationService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1")
+/**
+ * Read-only catalog endpoints for the mobile Home screen (activities list, featured, recommended, detail).
+ *
+ * Note: `/activities/recommended` supports a temporary `userId` query param for development, and can also
+ * derive the user id from a Bearer JWT payload once authentication is integrated.
+ */
+public class ActivityController {
+
+    private final ActivityCatalogService catalogService;
+    private final RecommendationService recommendationService;
+
+    public ActivityController(ActivityCatalogService catalogService, RecommendationService recommendationService) {
+        this.catalogService = catalogService;
+        this.recommendationService = recommendationService;
+    }
+
+    @GetMapping("/activities")
+    public PageResponse<ActivitySummaryDto> listActivities(
+            @RequestParam(required = false) @Min(0) Integer page,
+            @RequestParam(required = false) @Min(1) @Max(100) Integer size,
+            @RequestParam(required = false) Long destinationId,
+            @RequestParam(required = false) ActivityCategory category,
+            @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date,
+            @RequestParam(required = false) BigDecimal minPrice,
+            @RequestParam(required = false) BigDecimal maxPrice
+    ) {
+        return catalogService.listActivities(page, size, destinationId, category, date, minPrice, maxPrice, false);
+    }
+
+    @GetMapping("/activities/featured")
+    public PageResponse<ActivitySummaryDto> listFeatured(
+            @RequestParam(required = false) @Min(0) Integer page,
+            @RequestParam(required = false) @Min(1) @Max(100) Integer size,
+            @RequestParam(required = false) Long destinationId,
+            @RequestParam(required = false) ActivityCategory category,
+            @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date,
+            @RequestParam(required = false) BigDecimal minPrice,
+            @RequestParam(required = false) BigDecimal maxPrice
+    ) {
+        return catalogService.listActivities(page, size, destinationId, category, date, minPrice, maxPrice, true);
+    }
+
+    @GetMapping("/activities/recommended")
+    public PageResponse<ActivitySummaryDto> listRecommended(
+            @RequestParam(required = false) Long userId,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam(required = false) @Min(0) Integer page,
+            @RequestParam(required = false) @Min(1) @Max(100) Integer size,
+            @RequestParam(required = false) Long destinationId,
+            @RequestParam(required = false) ActivityCategory category
+    ) {
+        Long resolvedUserId = userId != null ? userId : JwtUserIdExtractor.tryExtractUserIdFromAuthorizationHeader(authorization);
+        if (resolvedUserId == null) {
+            throw new IllegalArgumentException("userId is required (provide query param or a Bearer JWT with userId/sub)");
+        }
+        return recommendationService.listRecommended(resolvedUserId, page, size, destinationId, category);
+    }
+
+    @GetMapping("/activities/{activityId}")
+    public ActivityDetailDto getActivityDetail(
+            @PathVariable Long activityId,
+            @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date
+    ) {
+        return catalogService.getActivityDetail(activityId, date);
+    }
+
+    @GetMapping("/categories")
+    public List<String> listCategories() {
+        return java.util.Arrays.stream(ActivityCategory.values())
+                .map(Enum::name)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/desabackend/controller/DestinationController.java
+++ b/src/main/java/com/example/desabackend/controller/DestinationController.java
@@ -1,0 +1,27 @@
+package com.example.desabackend.controller;
+
+import com.example.desabackend.dto.DestinationDto;
+import com.example.desabackend.service.DestinationService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+/**
+ * Auxiliary endpoints used by the mobile client to populate catalog filters (destinations list).
+ */
+public class DestinationController {
+
+    private final DestinationService destinationService;
+
+    public DestinationController(DestinationService destinationService) {
+        this.destinationService = destinationService;
+    }
+
+    @GetMapping("/destinations")
+    public List<DestinationDto> listDestinations() {
+        return destinationService.listDestinations();
+    }
+}

--- a/src/main/java/com/example/desabackend/controller/JwtUserIdExtractor.java
+++ b/src/main/java/com/example/desabackend/controller/JwtUserIdExtractor.java
@@ -1,0 +1,86 @@
+package com.example.desabackend.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+final class JwtUserIdExtractor {
+
+    /**
+     * Extracts a numeric user id from a JWT payload without validating the signature.
+     *
+     * This is meant as a compatibility bridge for the TP until Spring Security/JWT validation is in place.
+     * In production you should rely on the security layer to validate the token and expose the user id.
+     */
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    private JwtUserIdExtractor() {
+    }
+
+    static Long tryExtractUserIdFromAuthorizationHeader(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            return null;
+        }
+        String prefix = "Bearer ";
+        if (!authorizationHeader.startsWith(prefix)) {
+            return null;
+        }
+        String token = authorizationHeader.substring(prefix.length()).trim();
+        return tryExtractUserIdFromJwt(token);
+    }
+
+    static Long tryExtractUserIdFromJwt(String jwt) {
+        if (jwt == null || jwt.isBlank()) {
+            return null;
+        }
+
+        // JWT format: header.payload.signature (Base64URL). We only decode payload.
+        String[] parts = jwt.split("\\.");
+        if (parts.length < 2) {
+            return null;
+        }
+
+        try {
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(parts[1]);
+            String payloadJson = new String(payloadBytes, StandardCharsets.UTF_8);
+            Map<String, Object> payload = OBJECT_MAPPER.readValue(payloadJson, MAP_TYPE);
+
+            Object userId = payload.get("userId");
+            Long parsed = parseLong(userId);
+            if (parsed != null) {
+                return parsed;
+            }
+
+            parsed = parseLong(payload.get("id"));
+            if (parsed != null) {
+                return parsed;
+            }
+
+            // Common fallback for many JWT setups: subject contains user identifier.
+            return parseLong(payload.get("sub"));
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static Long parseLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        if (value instanceof String s) {
+            try {
+                return Long.parseLong(s);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/desabackend/dto/ActivityDetailDto.java
+++ b/src/main/java/com/example/desabackend/dto/ActivityDetailDto.java
@@ -1,0 +1,27 @@
+package com.example.desabackend.dto;
+
+import com.example.desabackend.entity.ActivityCategory;
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Full activity detail for the activity screen, including upcoming sessions and computed availability.
+ */
+public record ActivityDetailDto(
+        Long id,
+        String name,
+        DestinationDto destination,
+        ActivityCategory category,
+        String description,
+        String includesText,
+        String meetingPoint,
+        GuideDto guide,
+        int durationMinutes,
+        String language,
+        String cancellationPolicy,
+        BigDecimal basePrice,
+        String currency,
+        List<ActivitySessionDto> sessions,
+        int availableSpots
+) {
+}

--- a/src/main/java/com/example/desabackend/dto/ActivitySessionDto.java
+++ b/src/main/java/com/example/desabackend/dto/ActivitySessionDto.java
@@ -1,0 +1,17 @@
+package com.example.desabackend.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * A single scheduled session ("salida") for an activity, including capacity and effective price.
+ */
+public record ActivitySessionDto(
+        Long id,
+        LocalDateTime startTime,
+        int capacity,
+        int bookedCount,
+        int availableSpots,
+        BigDecimal price
+) {
+}

--- a/src/main/java/com/example/desabackend/dto/ActivitySummaryDto.java
+++ b/src/main/java/com/example/desabackend/dto/ActivitySummaryDto.java
@@ -1,0 +1,19 @@
+package com.example.desabackend.dto;
+
+import com.example.desabackend.entity.ActivityCategory;
+import java.math.BigDecimal;
+
+/**
+ * Compact activity card for the Home catalog list.
+ */
+public record ActivitySummaryDto(
+        Long id,
+        String name,
+        DestinationDto destination,
+        ActivityCategory category,
+        int durationMinutes,
+        BigDecimal price,
+        String currency,
+        int availableSpots
+) {
+}

--- a/src/main/java/com/example/desabackend/dto/DestinationDto.java
+++ b/src/main/java/com/example/desabackend/dto/DestinationDto.java
@@ -1,0 +1,10 @@
+package com.example.desabackend.dto;
+
+/**
+ * Minimal destination representation for lists and activity summaries.
+ */
+public record DestinationDto(
+        Long id,
+        String name
+) {
+}

--- a/src/main/java/com/example/desabackend/dto/GuideDto.java
+++ b/src/main/java/com/example/desabackend/dto/GuideDto.java
@@ -1,0 +1,10 @@
+package com.example.desabackend.dto;
+
+/**
+ * Minimal guide representation for activity detail responses.
+ */
+public record GuideDto(
+        Long id,
+        String fullName
+) {
+}

--- a/src/main/java/com/example/desabackend/dto/PageResponse.java
+++ b/src/main/java/com/example/desabackend/dto/PageResponse.java
@@ -1,0 +1,15 @@
+package com.example.desabackend.dto;
+
+import java.util.List;
+
+/**
+ * Stable pagination wrapper for Android clients (avoid Spring's default Page JSON shape).
+ */
+public record PageResponse<T>(
+        List<T> items,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/example/desabackend/entity/ActivityCategory.java
+++ b/src/main/java/com/example/desabackend/entity/ActivityCategory.java
@@ -1,0 +1,13 @@
+package com.example.desabackend.entity;
+
+/**
+ * Catalog categories supported by the mobile filters and activity cards.
+ */
+public enum ActivityCategory {
+    FREE_TOUR,
+    VISITA_GUIADA,
+    EXCURSION,
+    GASTRONOMIA,
+    AVENTURA,
+    OTRA
+}

--- a/src/main/java/com/example/desabackend/entity/ActivityEntity.java
+++ b/src/main/java/com/example/desabackend/entity/ActivityEntity.java
@@ -1,0 +1,82 @@
+package com.example.desabackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "activities")
+/**
+ * Core activity/tour entity shown in the catalog.
+ *
+ * Availability and "next session" data is derived from {@link ActivitySessionEntity}.
+ */
+public class ActivityEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(columnDefinition = "TEXT")
+    private String includesText;
+
+    @Column(length = 255)
+    private String meetingPoint;
+
+    @Column(nullable = false)
+    private Integer durationMinutes;
+
+    @Column(length = 10)
+    private String language;
+
+    @Column(columnDefinition = "TEXT")
+    private String cancellationPolicy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private ActivityCategory category;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal basePrice;
+
+    @Column(nullable = false, length = 5)
+    private String currency;
+
+    @Column(nullable = false)
+    private boolean featured = false;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "destination_id", nullable = false)
+    private DestinationEntity destination;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guide_id")
+    private GuideEntity guide;
+
+    @OneToMany(mappedBy = "activity", fetch = FetchType.LAZY)
+    private List<ActivitySessionEntity> sessions = new ArrayList<>();
+}

--- a/src/main/java/com/example/desabackend/entity/ActivitySessionEntity.java
+++ b/src/main/java/com/example/desabackend/entity/ActivitySessionEntity.java
@@ -1,0 +1,54 @@
+package com.example.desabackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Index;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "activity_sessions",
+        indexes = {
+                @Index(name = "idx_activity_sessions_activity_start", columnList = "activity_id,start_time"),
+                @Index(name = "idx_activity_sessions_start", columnList = "start_time")
+        }
+)
+/**
+ * Scheduled session ("salida") for an activity, used to calculate availability and effective price.
+ */
+public class ActivitySessionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private ActivityEntity activity;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private Integer capacity;
+
+    @Column(nullable = false)
+    private Integer bookedCount;
+
+    @Column(precision = 10, scale = 2)
+    private BigDecimal priceOverride;
+}

--- a/src/main/java/com/example/desabackend/entity/DestinationEntity.java
+++ b/src/main/java/com/example/desabackend/entity/DestinationEntity.java
@@ -1,0 +1,35 @@
+package com.example.desabackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "destinations")
+/**
+ * Destination master data (used by activities and by the destination filter).
+ */
+public class DestinationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(length = 100)
+    private String country;
+
+    @Column(length = 120)
+    private String city;
+}

--- a/src/main/java/com/example/desabackend/entity/GuideEntity.java
+++ b/src/main/java/com/example/desabackend/entity/GuideEntity.java
@@ -1,0 +1,32 @@
+package com.example.desabackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "guides")
+/**
+ * Activity guide (assigned to an activity; not used for auth).
+ */
+public class GuideEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String fullName;
+
+    @Column(length = 200)
+    private String languages;
+}

--- a/src/main/java/com/example/desabackend/entity/UserPreferredCategoryEntity.java
+++ b/src/main/java/com/example/desabackend/entity/UserPreferredCategoryEntity.java
@@ -1,0 +1,41 @@
+package com.example.desabackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "user_preferred_categories",
+        indexes = {
+                @Index(name = "idx_upc_user_id", columnList = "user_id")
+        }
+)
+/**
+ * User category preferences used to rank recommended activities.
+ */
+public class UserPreferredCategoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 40)
+    private ActivityCategory category;
+}

--- a/src/main/java/com/example/desabackend/entity/UserPreferredDestinationEntity.java
+++ b/src/main/java/com/example/desabackend/entity/UserPreferredDestinationEntity.java
@@ -1,0 +1,39 @@
+package com.example.desabackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "user_preferred_destinations",
+        indexes = {
+                @Index(name = "idx_upd_user_id", columnList = "user_id"),
+                @Index(name = "idx_upd_dest_id", columnList = "destination_id")
+        }
+)
+/**
+ * User preference link for recommendations (kept independent from the auth user table).
+ */
+public class UserPreferredDestinationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "destination_id", nullable = false)
+    private Long destinationId;
+}

--- a/src/main/java/com/example/desabackend/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/example/desabackend/exception/ApiExceptionHandler.java
@@ -1,0 +1,58 @@
+package com.example.desabackend.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@ControllerAdvice
+/**
+ * Centralized REST error mapping to a stable JSON shape for Android.
+ */
+public class ApiExceptionHandler {
+
+    public record ApiError(
+            Instant timestamp,
+            int status,
+            String error,
+            String message,
+            String path
+    ) {
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(NotFoundException ex, HttpServletRequest request) {
+        return build(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler({
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class,
+            MethodArgumentNotValidException.class,
+            IllegalArgumentException.class
+    })
+    public ResponseEntity<ApiError> handleBadRequest(Exception ex, HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleInternal(Exception ex, HttpServletRequest request) {
+        return build(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error", request);
+    }
+
+    private static ResponseEntity<ApiError> build(HttpStatus status, String message, HttpServletRequest request) {
+        ApiError body = new ApiError(
+                Instant.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                message,
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(status).body(body);
+    }
+}

--- a/src/main/java/com/example/desabackend/exception/NotFoundException.java
+++ b/src/main/java/com/example/desabackend/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.example.desabackend.exception;
+
+/**
+ * Simple domain exception used to map not-found resources to HTTP 404.
+ */
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/desabackend/repository/ActivityRepository.java
+++ b/src/main/java/com/example/desabackend/repository/ActivityRepository.java
@@ -1,0 +1,56 @@
+package com.example.desabackend.repository;
+
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.entity.ActivityEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.domain.Specification;
+
+/**
+ * Activity persistence + a custom query used to order "recommended" activities.
+ *
+ * Uses {@link EntityGraph} to eagerly load destination/guide for list endpoints (avoid N+1 with open-in-view=false).
+ */
+public interface ActivityRepository extends JpaRepository<ActivityEntity, Long>, JpaSpecificationExecutor<ActivityEntity> {
+
+    @Override
+    @EntityGraph(attributePaths = {"destination", "guide"})
+    Page<ActivityEntity> findAll(Specification<ActivityEntity> spec, Pageable pageable);
+
+    @Query("""
+            select a
+            from ActivityEntity a
+            where (:destinationId is null or a.destination.id = :destinationId)
+              and (:category is null or a.category = :category)
+              and (:featuredOnly = false or a.featured = true)
+            order by
+              (
+                (case when :prefDestEmpty = true then 0 when a.destination.id in :preferredDestinationIds then 2 else 0 end)
+                +
+                (case when :prefCatEmpty = true then 0 when a.category in :preferredCategories then 1 else 0 end)
+              ) desc,
+              a.featured desc,
+              (case when (select min(s.startTime) from ActivitySessionEntity s where s.activity = a and s.startTime >= :now) is null then 1 else 0 end) asc,
+              (select min(s2.startTime) from ActivitySessionEntity s2 where s2.activity = a and s2.startTime >= :now) asc,
+              a.id asc
+            """)
+    @EntityGraph(attributePaths = {"destination", "guide"})
+    Page<ActivityEntity> findRecommended(
+            @Param("destinationId") Long destinationId,
+            @Param("category") ActivityCategory category,
+            @Param("featuredOnly") boolean featuredOnly,
+            @Param("preferredDestinationIds") List<Long> preferredDestinationIds,
+            @Param("preferredCategories") List<ActivityCategory> preferredCategories,
+            @Param("prefDestEmpty") boolean prefDestEmpty,
+            @Param("prefCatEmpty") boolean prefCatEmpty,
+            @Param("now") LocalDateTime now,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/example/desabackend/repository/ActivitySessionRepository.java
+++ b/src/main/java/com/example/desabackend/repository/ActivitySessionRepository.java
@@ -1,0 +1,88 @@
+package com.example.desabackend.repository;
+
+import com.example.desabackend.entity.ActivitySessionEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Session ("salida") queries and aggregations used to compute catalog card price and availability efficiently.
+ */
+public interface ActivitySessionRepository extends JpaRepository<ActivitySessionEntity, Long> {
+
+    interface ActivitySummaryAggregate {
+        Long getActivityId();
+
+        Long getAvailableSpots();
+
+        java.math.BigDecimal getPrice();
+    }
+
+    @Query("""
+            select s.activity.id as activityId,
+                   sum(case when (s.capacity - s.bookedCount) > 0 then (s.capacity - s.bookedCount) else 0 end) as availableSpots,
+                   min(coalesce(s.priceOverride, s.activity.basePrice)) as price
+            from ActivitySessionEntity s
+            where s.activity.id in :activityIds
+              and s.startTime >= :start
+              and s.startTime < :end
+              and (s.capacity - s.bookedCount) > 0
+              and (:minPrice is null or coalesce(s.priceOverride, s.activity.basePrice) >= :minPrice)
+              and (:maxPrice is null or coalesce(s.priceOverride, s.activity.basePrice) <= :maxPrice)
+            group by s.activity.id
+            """)
+    List<ActivitySummaryAggregate> aggregateForDate(
+            @Param("activityIds") List<Long> activityIds,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("minPrice") java.math.BigDecimal minPrice,
+            @Param("maxPrice") java.math.BigDecimal maxPrice
+    );
+
+    @Query("""
+            select s.activity.id as activityId,
+                   sum(case when (s.capacity - s.bookedCount) > 0 then (s.capacity - s.bookedCount) else 0 end) as availableSpots,
+                   min(coalesce(s.priceOverride, s.activity.basePrice)) as price
+            from ActivitySessionEntity s
+            where s.activity.id in :activityIds
+              and s.startTime = (
+                  select min(s2.startTime)
+                  from ActivitySessionEntity s2
+                  where s2.activity.id = s.activity.id
+                    and s2.startTime >= :now
+              )
+            group by s.activity.id
+            """)
+    List<ActivitySummaryAggregate> aggregateForNextSession(
+            @Param("activityIds") List<Long> activityIds,
+            @Param("now") LocalDateTime now
+    );
+
+    @Query("""
+            select s
+            from ActivitySessionEntity s
+            where s.activity.id = :activityId
+              and s.startTime >= :start
+              and s.startTime < :end
+            order by s.startTime asc
+            """)
+    List<ActivitySessionEntity> findByActivityIdAndDay(
+            @Param("activityId") Long activityId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+    @Query("""
+            select s
+            from ActivitySessionEntity s
+            where s.activity.id = :activityId
+              and s.startTime >= :now
+            order by s.startTime asc
+            """)
+    List<ActivitySessionEntity> findFutureByActivityId(
+            @Param("activityId") Long activityId,
+            @Param("now") LocalDateTime now
+    );
+}

--- a/src/main/java/com/example/desabackend/repository/DestinationRepository.java
+++ b/src/main/java/com/example/desabackend/repository/DestinationRepository.java
@@ -1,0 +1,10 @@
+package com.example.desabackend.repository;
+
+import com.example.desabackend.entity.DestinationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Destination persistence for filter lists.
+ */
+public interface DestinationRepository extends JpaRepository<DestinationEntity, Long> {
+}

--- a/src/main/java/com/example/desabackend/repository/GuideRepository.java
+++ b/src/main/java/com/example/desabackend/repository/GuideRepository.java
@@ -1,0 +1,10 @@
+package com.example.desabackend.repository;
+
+import com.example.desabackend.entity.GuideEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Guide persistence (referenced by activities).
+ */
+public interface GuideRepository extends JpaRepository<GuideEntity, Long> {
+}

--- a/src/main/java/com/example/desabackend/repository/UserPreferredCategoryRepository.java
+++ b/src/main/java/com/example/desabackend/repository/UserPreferredCategoryRepository.java
@@ -1,0 +1,12 @@
+package com.example.desabackend.repository;
+
+import com.example.desabackend.entity.UserPreferredCategoryEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * User category preferences used by the recommendation ranking.
+ */
+public interface UserPreferredCategoryRepository extends JpaRepository<UserPreferredCategoryEntity, Long> {
+    List<UserPreferredCategoryEntity> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/desabackend/repository/UserPreferredDestinationRepository.java
+++ b/src/main/java/com/example/desabackend/repository/UserPreferredDestinationRepository.java
@@ -1,0 +1,12 @@
+package com.example.desabackend.repository;
+
+import com.example.desabackend.entity.UserPreferredDestinationEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * User destination preferences used by the recommendation ranking.
+ */
+public interface UserPreferredDestinationRepository extends JpaRepository<UserPreferredDestinationEntity, Long> {
+    List<UserPreferredDestinationEntity> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/desabackend/service/ActivityCatalogService.java
+++ b/src/main/java/com/example/desabackend/service/ActivityCatalogService.java
@@ -1,0 +1,170 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.dto.ActivityDetailDto;
+import com.example.desabackend.dto.ActivitySessionDto;
+import com.example.desabackend.dto.ActivitySummaryDto;
+import com.example.desabackend.dto.PageResponse;
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.entity.ActivitySessionEntity;
+import com.example.desabackend.exception.NotFoundException;
+import com.example.desabackend.repository.ActivityRepository;
+import com.example.desabackend.repository.ActivitySessionRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+/**
+ * Catalog read model for the Home screen:
+ * - paginated list with combined filters
+ * - detail view with sessions
+ *
+ * Uses aggregated queries to avoid N+1 when computing price/availability for cards.
+ */
+public class ActivityCatalogService {
+
+    private final ActivityRepository activityRepository;
+    private final ActivitySessionRepository sessionRepository;
+
+    public ActivityCatalogService(ActivityRepository activityRepository, ActivitySessionRepository sessionRepository) {
+        this.activityRepository = activityRepository;
+        this.sessionRepository = sessionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ActivitySummaryDto> listActivities(
+            Integer page,
+            Integer size,
+            Long destinationId,
+            ActivityCategory category,
+            LocalDate date,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            boolean featuredOnly
+    ) {
+        int safePage = page == null ? 0 : Math.max(0, page);
+        int safeSize = size == null ? 10 : Math.min(100, Math.max(1, size));
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        LocalDateTime now = LocalDateTime.now();
+        var spec = ActivitySpecifications.forCatalog(destinationId, category, date, minPrice, maxPrice, now, featuredOnly);
+        Page<ActivityEntity> activitiesPage = activityRepository.findAll(spec, pageable);
+
+        List<Long> activityIds = activitiesPage.getContent().stream()
+                .map(ActivityEntity::getId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        Map<Long, ActivitySessionRepository.ActivitySummaryAggregate> aggregatesByActivityId =
+                aggregateForSummary(activityIds, date, minPrice, maxPrice, now).stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                ActivitySessionRepository.ActivitySummaryAggregate::getActivityId,
+                                Function.identity(),
+                                (a, b) -> a
+                        ));
+
+        List<ActivitySummaryDto> items = activitiesPage.getContent().stream()
+                .map(a -> ActivityDtoMapper.toSummaryDto(a, aggregatesByActivityId.get(a.getId())))
+                .toList();
+
+        return new PageResponse<>(
+                items,
+                activitiesPage.getNumber(),
+                activitiesPage.getSize(),
+                activitiesPage.getTotalElements(),
+                activitiesPage.getTotalPages()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ActivityDetailDto getActivityDetail(Long activityId, LocalDate date) {
+        ActivityEntity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new NotFoundException("Activity not found: " + activityId));
+
+        List<ActivitySessionEntity> sessions = fetchSessions(activityId, date);
+        List<ActivitySessionDto> sessionDtos = sessions.stream()
+                .map(ActivityDtoMapper::toSessionDto)
+                .toList();
+
+        int availableSpots = calculateAvailableSpotsForDetail(sessions, date);
+
+        return new ActivityDetailDto(
+                activity.getId(),
+                activity.getName(),
+                ActivityDtoMapper.toDestinationDto(activity),
+                activity.getCategory(),
+                activity.getDescription(),
+                activity.getIncludesText(),
+                activity.getMeetingPoint(),
+                ActivityDtoMapper.toGuideDto(activity),
+                ActivityDtoMapper.nonNullInt(activity.getDurationMinutes()),
+                activity.getLanguage(),
+                activity.getCancellationPolicy(),
+                activity.getBasePrice(),
+                activity.getCurrency(),
+                sessionDtos,
+                availableSpots
+        );
+    }
+
+    private List<ActivitySessionRepository.ActivitySummaryAggregate> aggregateForSummary(List<Long> activityIds, LocalDate date) {
+        return aggregateForSummary(activityIds, date, null, null, LocalDateTime.now());
+    }
+
+    private List<ActivitySessionRepository.ActivitySummaryAggregate> aggregateForSummary(
+            List<Long> activityIds,
+            LocalDate date,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            LocalDateTime now
+    ) {
+        if (activityIds.isEmpty()) {
+            return List.of();
+        }
+
+        if (date != null) {
+            LocalDateTime start = date.atStartOfDay();
+            LocalDateTime end = date.plusDays(1).atStartOfDay();
+            return sessionRepository.aggregateForDate(activityIds, start, end, minPrice, maxPrice);
+        }
+
+        return sessionRepository.aggregateForNextSession(activityIds, now == null ? LocalDateTime.now() : now);
+    }
+
+    private List<ActivitySessionEntity> fetchSessions(Long activityId, LocalDate date) {
+        if (date != null) {
+            LocalDateTime start = date.atStartOfDay();
+            LocalDateTime end = date.plusDays(1).atStartOfDay();
+            return sessionRepository.findByActivityIdAndDay(activityId, start, end);
+        }
+        return sessionRepository.findFutureByActivityId(activityId, LocalDateTime.now());
+    }
+
+    private static int calculateAvailableSpotsForDetail(List<ActivitySessionEntity> sessions, LocalDate date) {
+        if (sessions.isEmpty()) {
+            return 0;
+        }
+
+        if (date != null) {
+            return sessions.stream()
+                    .mapToInt(s -> Math.max(0, ActivityDtoMapper.nonNullInt(s.getCapacity()) - ActivityDtoMapper.nonNullInt(s.getBookedCount())))
+                    .sum();
+        }
+
+        LocalDateTime firstStartTime = sessions.get(0).getStartTime();
+        return sessions.stream()
+                .filter(s -> Objects.equals(firstStartTime, s.getStartTime()))
+                .mapToInt(s -> Math.max(0, ActivityDtoMapper.nonNullInt(s.getCapacity()) - ActivityDtoMapper.nonNullInt(s.getBookedCount())))
+                .sum();
+    }
+}

--- a/src/main/java/com/example/desabackend/service/ActivityDtoMapper.java
+++ b/src/main/java/com/example/desabackend/service/ActivityDtoMapper.java
@@ -1,0 +1,73 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.dto.ActivitySessionDto;
+import com.example.desabackend.dto.ActivitySummaryDto;
+import com.example.desabackend.dto.DestinationDto;
+import com.example.desabackend.dto.GuideDto;
+import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.entity.ActivitySessionEntity;
+import com.example.desabackend.repository.ActivitySessionRepository;
+import java.math.BigDecimal;
+
+final class ActivityDtoMapper {
+
+    /**
+     * Centralized DTO mapping to keep controller/service code small and consistent.
+     */
+    private ActivityDtoMapper() {
+    }
+
+    static ActivitySummaryDto toSummaryDto(ActivityEntity activity, ActivitySessionRepository.ActivitySummaryAggregate agg) {
+        BigDecimal price = agg != null && agg.getPrice() != null ? agg.getPrice() : activity.getBasePrice();
+        int availableSpots = agg != null && agg.getAvailableSpots() != null ? Math.toIntExact(agg.getAvailableSpots()) : 0;
+
+        return new ActivitySummaryDto(
+                activity.getId(),
+                activity.getName(),
+                toDestinationDto(activity),
+                activity.getCategory(),
+                nonNullInt(activity.getDurationMinutes()),
+                price,
+                activity.getCurrency(),
+                availableSpots
+        );
+    }
+
+    static ActivitySessionDto toSessionDto(ActivitySessionEntity session) {
+        int capacity = nonNullInt(session.getCapacity());
+        int booked = nonNullInt(session.getBookedCount());
+        int available = Math.max(0, capacity - booked);
+
+        BigDecimal price = session.getPriceOverride();
+        if (price == null && session.getActivity() != null) {
+            price = session.getActivity().getBasePrice();
+        }
+
+        return new ActivitySessionDto(
+                session.getId(),
+                session.getStartTime(),
+                capacity,
+                booked,
+                available,
+                price
+        );
+    }
+
+    static DestinationDto toDestinationDto(ActivityEntity activity) {
+        if (activity.getDestination() == null) {
+            return null;
+        }
+        return new DestinationDto(activity.getDestination().getId(), activity.getDestination().getName());
+    }
+
+    static GuideDto toGuideDto(ActivityEntity activity) {
+        if (activity.getGuide() == null) {
+            return null;
+        }
+        return new GuideDto(activity.getGuide().getId(), activity.getGuide().getFullName());
+    }
+
+    static int nonNullInt(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/src/main/java/com/example/desabackend/service/ActivitySpecifications.java
+++ b/src/main/java/com/example/desabackend/service/ActivitySpecifications.java
@@ -1,0 +1,112 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.entity.ActivitySessionEntity;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.jpa.domain.Specification;
+
+final class ActivitySpecifications {
+
+    /**
+     * JPA Specifications for the catalog list endpoint (combined filters).
+     */
+    private ActivitySpecifications() {
+    }
+
+    static Specification<ActivityEntity> forCatalog(
+            Long destinationId,
+            ActivityCategory category,
+            LocalDate date,
+            BigDecimal minPrice,
+            BigDecimal maxPrice,
+            LocalDateTime now,
+            boolean featuredOnly
+    ) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (destinationId != null) {
+                predicates.add(cb.equal(root.get("destination").get("id"), destinationId));
+            }
+
+            if (category != null) {
+                predicates.add(cb.equal(root.get("category"), category));
+            }
+
+            if (featuredOnly) {
+                predicates.add(cb.isTrue(root.get("featured")));
+            }
+
+            if (date != null) {
+                LocalDateTime start = date.atStartOfDay();
+                LocalDateTime end = date.plusDays(1).atStartOfDay();
+
+                Join<ActivityEntity, ActivitySessionEntity> session = root.join("sessions", JoinType.INNER);
+                predicates.add(cb.greaterThanOrEqualTo(session.get("startTime"), start));
+                predicates.add(cb.lessThan(session.get("startTime"), end));
+
+                Expression<Integer> diff = cb.diff(session.get("capacity"), session.get("bookedCount")).as(Integer.class);
+                predicates.add(cb.greaterThan(diff, 0));
+
+                if (minPrice != null || maxPrice != null) {
+                    Expression<BigDecimal> effectivePrice = cb.<BigDecimal>coalesce(
+                            session.get("priceOverride"),
+                            root.get("basePrice")
+                    );
+                    if (minPrice != null) {
+                        predicates.add(cb.greaterThanOrEqualTo(effectivePrice, minPrice));
+                    }
+                    if (maxPrice != null) {
+                        predicates.add(cb.lessThanOrEqualTo(effectivePrice, maxPrice));
+                    }
+                }
+
+                query.distinct(true);
+            } else {
+                // When there's no date, the UI price comes from the next session. Keep filters aligned by filtering
+                // against the next future session effective price when min/max are provided.
+                if (minPrice != null || maxPrice != null) {
+                    final LocalDateTime effectiveNow = now == null ? LocalDateTime.now() : now;
+
+                    Join<ActivityEntity, ActivitySessionEntity> session = root.join("sessions", JoinType.INNER);
+
+                    var minStartTime = query.subquery(LocalDateTime.class);
+                    var s2 = minStartTime.from(ActivitySessionEntity.class);
+                    var s2StartTime = s2.get("startTime").as(LocalDateTime.class);
+                    minStartTime.select(cb.least(s2StartTime))
+                            .where(
+                                    cb.equal(s2.get("activity"), root),
+                                    cb.greaterThanOrEqualTo(s2StartTime, effectiveNow)
+                            );
+
+                    predicates.add(cb.equal(session.get("startTime"), minStartTime));
+
+                    Expression<BigDecimal> effectivePrice = cb.<BigDecimal>coalesce(
+                            session.get("priceOverride"),
+                            root.get("basePrice")
+                    );
+
+                    if (minPrice != null) {
+                        predicates.add(cb.greaterThanOrEqualTo(effectivePrice, minPrice));
+                    }
+                    if (maxPrice != null) {
+                        predicates.add(cb.lessThanOrEqualTo(effectivePrice, maxPrice));
+                    }
+
+                    query.distinct(true);
+                }
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/com/example/desabackend/service/DestinationService.java
+++ b/src/main/java/com/example/desabackend/service/DestinationService.java
@@ -1,0 +1,25 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.dto.DestinationDto;
+import com.example.desabackend.repository.DestinationRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+/**
+ * Read-only destination list service (used by filter UI).
+ */
+public class DestinationService {
+
+    private final DestinationRepository destinationRepository;
+
+    public DestinationService(DestinationRepository destinationRepository) {
+        this.destinationRepository = destinationRepository;
+    }
+
+    public List<DestinationDto> listDestinations() {
+        return destinationRepository.findAll().stream()
+                .map(d -> new DestinationDto(d.getId(), d.getName()))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/desabackend/service/RecommendationService.java
+++ b/src/main/java/com/example/desabackend/service/RecommendationService.java
@@ -1,0 +1,106 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.dto.ActivitySummaryDto;
+import com.example.desabackend.dto.PageResponse;
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.repository.ActivityRepository;
+import com.example.desabackend.repository.ActivitySessionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+/**
+ * Recommended activities use-case.
+ *
+ * Ranking is based on user preferences (destinations/categories) with simple scoring and deterministic tie-breakers.
+ */
+public class RecommendationService {
+
+    private final ActivityRepository activityRepository;
+    private final ActivitySessionRepository sessionRepository;
+    private final UserPreferenceService userPreferenceService;
+
+    public RecommendationService(
+            ActivityRepository activityRepository,
+            ActivitySessionRepository sessionRepository,
+            UserPreferenceService userPreferenceService
+    ) {
+        this.activityRepository = activityRepository;
+        this.sessionRepository = sessionRepository;
+        this.userPreferenceService = userPreferenceService;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ActivitySummaryDto> listRecommended(
+            long userId,
+            Integer page,
+            Integer size,
+            Long destinationId,
+            ActivityCategory category
+    ) {
+        int safePage = page == null ? 0 : Math.max(0, page);
+        int safeSize = size == null ? 10 : Math.min(100, Math.max(1, size));
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+
+        List<Long> preferredDestIds = userPreferenceService.getPreferredDestinationIds(userId);
+        List<ActivityCategory> preferredCategories = userPreferenceService.getPreferredCategories(userId);
+
+        boolean prefDestEmpty = preferredDestIds.isEmpty();
+        boolean prefCatEmpty = preferredCategories.isEmpty();
+
+        if (prefDestEmpty) {
+            preferredDestIds = List.of(0L);
+        }
+        if (prefCatEmpty) {
+            preferredCategories = List.of(ActivityCategory.OTRA);
+        }
+
+        Page<ActivityEntity> pageResult = activityRepository.findRecommended(
+                destinationId,
+                category,
+                false,
+                preferredDestIds,
+                preferredCategories,
+                prefDestEmpty,
+                prefCatEmpty,
+                LocalDateTime.now(),
+                pageable
+        );
+
+        List<Long> activityIds = pageResult.getContent().stream()
+                .map(ActivityEntity::getId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        Map<Long, ActivitySessionRepository.ActivitySummaryAggregate> aggregatesByActivityId =
+                (activityIds.isEmpty() ? List.<ActivitySessionRepository.ActivitySummaryAggregate>of()
+                        : sessionRepository.aggregateForNextSession(activityIds, LocalDateTime.now()))
+                        .stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                ActivitySessionRepository.ActivitySummaryAggregate::getActivityId,
+                                Function.identity(),
+                                (a, b) -> a
+                        ));
+
+        List<ActivitySummaryDto> items = pageResult.getContent().stream()
+                .map(a -> ActivityDtoMapper.toSummaryDto(a, aggregatesByActivityId.get(a.getId())))
+                .toList();
+
+        return new PageResponse<>(
+                items,
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/com/example/desabackend/service/UserPreferenceService.java
+++ b/src/main/java/com/example/desabackend/service/UserPreferenceService.java
@@ -1,0 +1,39 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.repository.UserPreferredCategoryRepository;
+import com.example.desabackend.repository.UserPreferredDestinationRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+/**
+ * Reads stored user preferences used to compute catalog recommendations.
+ */
+public class UserPreferenceService {
+
+    private final UserPreferredDestinationRepository destinationRepository;
+    private final UserPreferredCategoryRepository categoryRepository;
+
+    public UserPreferenceService(
+            UserPreferredDestinationRepository destinationRepository,
+            UserPreferredCategoryRepository categoryRepository
+    ) {
+        this.destinationRepository = destinationRepository;
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<Long> getPreferredDestinationIds(long userId) {
+        return destinationRepository.findByUserId(userId).stream()
+                .map(p -> p.getDestinationId())
+                .distinct()
+                .toList();
+    }
+
+    public List<ActivityCategory> getPreferredCategories(long userId) {
+        return categoryRepository.findByUserId(userId).stream()
+                .map(p -> p.getCategory())
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
 spring.application.name=desa-backend
+
+# --- DB (MySQL) ---
+spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/xplorenow?useSSL=false&serverTimezone=UTC}
+spring.datasource.username=${DB_USER:root}
+spring.datasource.password=${DB_PASS:root}
+
+# --- JPA ---
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.open-in-view=false
+spring.jpa.show-sql=true
+
+# This project uses LocalDate/LocalDateTime in DTOs; Jackson is configured via dependencies in pom.xml.


### PR DESCRIPTION
PR Description (ready to paste)

This PR adds the full REST API for XploreNow’s Home/Catálogo de Actividades (TP backend), built with Spring Boot + MySQL + Spring Data JPA (no images). It introduces the core domain model (activities, destinations, guides, scheduled sessions, and user preferences) and exposes read-only endpoints under /api/v1 for the Android app.

Key features:

Paginated activities catalog with combined filters: destinationId, category, date (YYYY-MM-DD), minPrice, maxPrice.
Featured activities endpoint (featured=true).
Recommended activities endpoint based on stored user preferences (destinations/categories) with deterministic ranking.
Activity detail endpoint returning full info + sessions list + computed availability.
Stable pagination contract via PageResponse<T> (instead of Spring Page default JSON).
Consistent JSON error responses (ApiError) for 400/404/500.
Business rules implemented:

With date: list only activities with at least one available session that day; summary availableSpots is the sum of available spots for that day and price is the min effective price that day.
Without date: summary availableSpots and price are derived from the next future session.
Price filters are aligned with how summary prices are computed (including next-session price when date is not provided).
Auth integration note (to avoid changes later):

/api/v1/activities/recommended supports either userId query param (temporary for dev) or deriving the user id from Authorization: Bearer <JWT> payload using numeric userId or id claims (or numeric sub). This is a bridge until the auth module is in place.
Performance/DB:

Uses aggregated queries for summary price/availability (avoids N+1 for sessions).
Uses @EntityGraph(destination, guide) to reduce N+1 on catalog/recommended lists.
Adds indexes for session lookups by (activity_id, start_time).