### PR TITLE
Expose activity average ratings

### DIFF
--- a/src/main/java/com/example/desabackend/dto/ActivityDetailDto.java
+++ b/src/main/java/com/example/desabackend/dto/ActivityDetailDto.java
@@ -22,6 +22,8 @@ public record ActivityDetailDto(
         BigDecimal basePrice,
         String currency,
         List<ActivitySessionDto> sessions,
-        int availableSpots
+        int availableSpots,
+        Double avgRating,
+        long reviewCount
 ) {
 }

--- a/src/main/java/com/example/desabackend/dto/ActivitySummaryDto.java
+++ b/src/main/java/com/example/desabackend/dto/ActivitySummaryDto.java
@@ -14,6 +14,8 @@ public record ActivitySummaryDto(
         int durationMinutes,
         BigDecimal price,
         String currency,
-        int availableSpots
+        int availableSpots,
+        Double avgRating,
+        long reviewCount
 ) {
 }

--- a/src/main/java/com/example/desabackend/repository/ReviewRepository.java
+++ b/src/main/java/com/example/desabackend/repository/ReviewRepository.java
@@ -1,11 +1,35 @@
 package com.example.desabackend.repository;
 
 import com.example.desabackend.entity.ReviewEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<ReviewEntity, Long> {
 
+    interface ActivityRatingAggregate {
+        Long getActivityId();
+        Double getAvgRating();
+        Long getReviewCount();
+    }
+
+    @Query("""
+            select r.activity.id as activityId, avg(r.activityRating) as avgRating, count(r.id) as reviewCount
+            from ReviewEntity r
+            where r.activity.id in :activityIds
+            group by r.activity.id
+            """)
+    List<ActivityRatingAggregate> aggregateActivityRatings(@Param("activityIds") List<Long> activityIds);
+
+    @Query("""
+            select r.activity.id as activityId, avg(r.activityRating) as avgRating, count(r.id) as reviewCount
+            from ReviewEntity r
+            where r.activity.id = :activityId
+            group by r.activity.id
+            """)
+    Optional<ActivityRatingAggregate> getActivityRating(@Param("activityId") Long activityId);
     boolean existsByBookingId(Long bookingId);
 
     Optional<ReviewEntity> findByBookingId(Long bookingId);

--- a/src/main/java/com/example/desabackend/service/ActivityCatalogService.java
+++ b/src/main/java/com/example/desabackend/service/ActivityCatalogService.java
@@ -10,6 +10,7 @@ import com.example.desabackend.entity.ActivitySessionEntity;
 import com.example.desabackend.exception.NotFoundException;
 import com.example.desabackend.repository.ActivityRepository;
 import com.example.desabackend.repository.ActivitySessionRepository;
+import com.example.desabackend.repository.ReviewRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -35,10 +36,12 @@ public class ActivityCatalogService {
 
     private final ActivityRepository activityRepository;
     private final ActivitySessionRepository sessionRepository;
+    private final ReviewRepository reviewRepository;
 
-    public ActivityCatalogService(ActivityRepository activityRepository, ActivitySessionRepository sessionRepository) {
+    public ActivityCatalogService(ActivityRepository activityRepository, ActivitySessionRepository sessionRepository, ReviewRepository reviewRepository) {
         this.activityRepository = activityRepository;
         this.sessionRepository = sessionRepository;
+        this.reviewRepository = reviewRepository;
     }
 
     @Transactional(readOnly = true)
@@ -72,9 +75,17 @@ public class ActivityCatalogService {
                                 Function.identity(),
                                 (a, b) -> a
                         ));
-
+        Map<Long, ReviewRepository.ActivityRatingAggregate> ratingsByActivityId =
+                (activityIds.isEmpty() ? List.<ReviewRepository.ActivityRatingAggregate>of()
+                        : reviewRepository.aggregateActivityRatings(activityIds))
+                        .stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                ReviewRepository.ActivityRatingAggregate::getActivityId,
+                                Function.identity(),
+                                (a, b) -> a
+                        ));
         List<ActivitySummaryDto> items = activitiesPage.getContent().stream()
-                .map(a -> ActivityDtoMapper.toSummaryDto(a, aggregatesByActivityId.get(a.getId())))
+                .map(a -> ActivityDtoMapper.toSummaryDto(a, aggregatesByActivityId.get(a.getId()), ratingsByActivityId.get(a.getId())))
                 .toList();
 
         return new PageResponse<>(
@@ -98,6 +109,10 @@ public class ActivityCatalogService {
 
         int availableSpots = calculateAvailableSpotsForDetail(sessions, date);
 
+        ReviewRepository.ActivityRatingAggregate ratingAgg = reviewRepository.getActivityRating(activityId).orElse(null);
+        Double avgRating = ratingAgg != null ? ratingAgg.getAvgRating() : null;
+        long reviewCount = ratingAgg != null && ratingAgg.getReviewCount() != null ? ratingAgg.getReviewCount() : 0L;
+
         return new ActivityDetailDto(
                 activity.getId(),
                 activity.getName(),
@@ -113,7 +128,9 @@ public class ActivityCatalogService {
                 activity.getBasePrice(),
                 activity.getCurrency(),
                 sessionDtos,
-                availableSpots
+                availableSpots,
+                avgRating,
+                reviewCount
         );
     }
 

--- a/src/main/java/com/example/desabackend/service/ActivityDtoMapper.java
+++ b/src/main/java/com/example/desabackend/service/ActivityDtoMapper.java
@@ -20,7 +20,7 @@ final class ActivityDtoMapper {
 
     static ActivitySummaryDto toSummaryDto(ActivityEntity activity, ActivitySessionRepository.ActivitySummaryAggregate agg, ReviewRepository.ActivityRatingAggregate ratingAgg) {
         BigDecimal price = agg != null && agg.getPrice() != null ? agg.getPrice() : activity.getBasePrice();
-        int availableSpots = ;
+        int availableSpots = agg != null && agg.getAvailableSpots() != null ? Math.toIntExact(agg.getAvailableSpots()) : 0;
         Double avgRating = ratingAgg != null ? ratingAgg.getAvgRating() : null;
         long reviewCount = ratingAgg != null && ratingAgg.getReviewCount() != null ? ratingAgg.getReviewCount() : 0L;
 

--- a/src/main/java/com/example/desabackend/service/ActivityDtoMapper.java
+++ b/src/main/java/com/example/desabackend/service/ActivityDtoMapper.java
@@ -7,6 +7,7 @@ import com.example.desabackend.dto.GuideDto;
 import com.example.desabackend.entity.ActivityEntity;
 import com.example.desabackend.entity.ActivitySessionEntity;
 import com.example.desabackend.repository.ActivitySessionRepository;
+import com.example.desabackend.repository.ReviewRepository;
 import java.math.BigDecimal;
 
 final class ActivityDtoMapper {
@@ -17,9 +18,11 @@ final class ActivityDtoMapper {
     private ActivityDtoMapper() {
     }
 
-    static ActivitySummaryDto toSummaryDto(ActivityEntity activity, ActivitySessionRepository.ActivitySummaryAggregate agg) {
+    static ActivitySummaryDto toSummaryDto(ActivityEntity activity, ActivitySessionRepository.ActivitySummaryAggregate agg, ReviewRepository.ActivityRatingAggregate ratingAgg) {
         BigDecimal price = agg != null && agg.getPrice() != null ? agg.getPrice() : activity.getBasePrice();
-        int availableSpots = agg != null && agg.getAvailableSpots() != null ? Math.toIntExact(agg.getAvailableSpots()) : 0;
+        int availableSpots = ;
+        Double avgRating = ratingAgg != null ? ratingAgg.getAvgRating() : null;
+        long reviewCount = ratingAgg != null && ratingAgg.getReviewCount() != null ? ratingAgg.getReviewCount() : 0L;
 
         return new ActivitySummaryDto(
                 activity.getId(),
@@ -29,7 +32,9 @@ final class ActivityDtoMapper {
                 nonNullInt(activity.getDurationMinutes()),
                 price,
                 activity.getCurrency(),
-                availableSpots
+                availableSpots,
+                avgRating,
+                reviewCount
         );
     }
 

--- a/src/main/java/com/example/desabackend/service/RecommendationService.java
+++ b/src/main/java/com/example/desabackend/service/RecommendationService.java
@@ -6,6 +6,7 @@ import com.example.desabackend.entity.ActivityCategory;
 import com.example.desabackend.entity.ActivityEntity;
 import com.example.desabackend.repository.ActivityRepository;
 import com.example.desabackend.repository.ActivitySessionRepository;
+import com.example.desabackend.repository.ReviewRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ public class RecommendationService {
 
     private final ActivityRepository activityRepository;
     private final ActivitySessionRepository sessionRepository;
+    private final ReviewRepository reviewRepository;
     private final UserPreferenceService userPreferenceService;
 
     public RecommendationService(
@@ -36,6 +38,7 @@ public class RecommendationService {
     ) {
         this.activityRepository = activityRepository;
         this.sessionRepository = sessionRepository;
+        this.reviewRepository = reviewRepository;
         this.userPreferenceService = userPreferenceService;
     }
 
@@ -90,9 +93,17 @@ public class RecommendationService {
                                 Function.identity(),
                                 (a, b) -> a
                         ));
-
+        Map<Long, ReviewRepository.ActivityRatingAggregate> ratingsByActivityId =
+                (activityIds.isEmpty() ? List.<ReviewRepository.ActivityRatingAggregate>of()
+                        : reviewRepository.aggregateActivityRatings(activityIds))
+                        .stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                ReviewRepository.ActivityRatingAggregate::getActivityId,
+                                Function.identity(),
+                                (a, b) -> a
+                        ));
         List<ActivitySummaryDto> items = pageResult.getContent().stream()
-                .map(a -> ActivityDtoMapper.toSummaryDto(a, aggregatesByActivityId.get(a.getId())))
+                .map(a -> ActivityDtoMapper.toSummaryDto(a, aggregatesByActivityId.get(a.getId()), ratingsByActivityId.get(a.getId())))
                 .toList();
 
         return new PageResponse<>(

--- a/src/main/java/com/example/desabackend/service/RecommendationService.java
+++ b/src/main/java/com/example/desabackend/service/RecommendationService.java
@@ -34,6 +34,7 @@ public class RecommendationService {
     public RecommendationService(
             ActivityRepository activityRepository,
             ActivitySessionRepository sessionRepository,
+            ReviewRepository reviewRepository,
             UserPreferenceService userPreferenceService
     ) {
         this.activityRepository = activityRepository;

--- a/src/test/java/com/example/desabackend/service/ActivityCatalogServiceTest.java
+++ b/src/test/java/com/example/desabackend/service/ActivityCatalogServiceTest.java
@@ -1,0 +1,136 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.entity.ActivitySessionEntity;
+import com.example.desabackend.entity.DestinationEntity;
+import com.example.desabackend.entity.GuideEntity;
+import com.example.desabackend.repository.ActivityRepository;
+import com.example.desabackend.repository.ActivitySessionRepository;
+import com.example.desabackend.repository.ReviewRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.jpa.domain.Specification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityCatalogServiceTest {
+
+    @Mock
+    private ActivityRepository activityRepository;
+    @Mock
+    private ActivitySessionRepository sessionRepository;
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    private ActivityCatalogService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ActivityCatalogService(activityRepository, sessionRepository, reviewRepository);
+    }
+
+    @Test
+    void listActivities_includesAverageRatingAndReviewCountInSummary() {
+        ActivityEntity activity = createActivity(1L, "Rafting");
+        ActivitySessionRepository.ActivitySummaryAggregate sessionAgg =
+            sessionAggregate(1L, 5L, new BigDecimal("9500.00"));
+        ReviewRepository.ActivityRatingAggregate ratingAgg = ratingAggregate(1L, 4.8, 23L);
+
+        when(activityRepository.findAll(any(Specification.class), any(org.springframework.data.domain.Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(activity)));
+        when(sessionRepository.aggregateForNextSession(eq(List.of(1L)), any(LocalDateTime.class)))
+            .thenReturn(List.of(sessionAgg));
+        when(reviewRepository.aggregateActivityRatings(eq(List.of(1L))))
+            .thenReturn(List.of(ratingAgg));
+
+        var result = service.listActivities(0, 10, null, null, null, null, null, false);
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).avgRating()).isEqualTo(4.8);
+        assertThat(result.items().get(0).reviewCount()).isEqualTo(23L);
+        assertThat(result.items().get(0).price()).isEqualByComparingTo("9500.00");
+    }
+
+    @Test
+    void getActivityDetail_withoutReviews_defaultsToNullRatingAndZeroCount() {
+        ActivityEntity activity = createActivity(2L, "City Tour");
+        ActivitySessionEntity session = new ActivitySessionEntity();
+        session.setId(100L);
+        session.setActivity(activity);
+        session.setStartTime(LocalDateTime.now().plusDays(1));
+        session.setCapacity(10);
+        session.setBookedCount(3);
+        session.setPriceOverride(new BigDecimal("5000.00"));
+
+        when(activityRepository.findById(2L)).thenReturn(Optional.of(activity));
+        when(sessionRepository.findFutureByActivityId(eq(2L), any(LocalDateTime.class)))
+                .thenReturn(List.of(session));
+        when(reviewRepository.getActivityRating(2L)).thenReturn(Optional.empty());
+
+        var result = service.getActivityDetail(2L, null);
+
+        assertThat(result.avgRating()).isNull();
+        assertThat(result.reviewCount()).isZero();
+        assertThat(result.availableSpots()).isEqualTo(7);
+        assertThat(result.sessions()).hasSize(1);
+    }
+
+    private static ActivityEntity createActivity(Long id, String name) {
+        ActivityEntity activity = new ActivityEntity();
+        activity.setId(id);
+        activity.setName(name);
+        activity.setCategory(ActivityCategory.AVENTURA);
+        activity.setDescription("desc");
+        activity.setIncludesText("includes");
+        activity.setMeetingPoint("meeting");
+        activity.setDurationMinutes(120);
+        activity.setLanguage("es");
+        activity.setCancellationPolicy("flex");
+        activity.setBasePrice(new BigDecimal("10000.00"));
+        activity.setCurrency("ARS");
+
+        DestinationEntity destination = new DestinationEntity();
+        destination.setId(10L);
+        destination.setName("Mendoza");
+        activity.setDestination(destination);
+
+        GuideEntity guide = new GuideEntity();
+        guide.setId(20L);
+        guide.setFullName("Ana Guide");
+        activity.setGuide(guide);
+        return activity;
+    }
+
+    private static ActivitySessionRepository.ActivitySummaryAggregate sessionAggregate(
+            Long activityId, Long availableSpots, BigDecimal price) {
+        ActivitySessionRepository.ActivitySummaryAggregate aggregate =
+                mock(ActivitySessionRepository.ActivitySummaryAggregate.class);
+        when(aggregate.getActivityId()).thenReturn(activityId);
+        when(aggregate.getAvailableSpots()).thenReturn(availableSpots);
+        when(aggregate.getPrice()).thenReturn(price);
+        return aggregate;
+    }
+
+    private static ReviewRepository.ActivityRatingAggregate ratingAggregate(Long activityId, Double avgRating, Long reviewCount) {
+        ReviewRepository.ActivityRatingAggregate aggregate = mock(ReviewRepository.ActivityRatingAggregate.class);
+        when(aggregate.getActivityId()).thenReturn(activityId);
+        when(aggregate.getAvgRating()).thenReturn(avgRating);
+        when(aggregate.getReviewCount()).thenReturn(reviewCount);
+        return aggregate;
+    }
+}

--- a/src/test/java/com/example/desabackend/service/ActivityDtoMapperTest.java
+++ b/src/test/java/com/example/desabackend/service/ActivityDtoMapperTest.java
@@ -1,0 +1,73 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.entity.DestinationEntity;
+import com.example.desabackend.repository.ActivitySessionRepository;
+import com.example.desabackend.repository.ReviewRepository;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ActivityDtoMapperTest {
+
+    @Test
+    void toSummaryDto_mapsRatingFieldsAndFallbacks() {
+        ActivityEntity activity = new ActivityEntity();
+        activity.setId(7L);
+        activity.setName("Kayak");
+        activity.setCategory(ActivityCategory.AVENTURA);
+        activity.setDurationMinutes(90);
+        activity.setBasePrice(new BigDecimal("1500.00"));
+        activity.setCurrency("ARS");
+
+        DestinationEntity destination = new DestinationEntity();
+        destination.setId(3L);
+        destination.setName("Ushuaia");
+        activity.setDestination(destination);
+
+        ActivitySessionRepository.ActivitySummaryAggregate sessionAgg =
+                mock(ActivitySessionRepository.ActivitySummaryAggregate.class);
+        when(sessionAgg.getPrice()).thenReturn(new BigDecimal("1200.00"));
+        when(sessionAgg.getAvailableSpots()).thenReturn(8L);
+
+        ReviewRepository.ActivityRatingAggregate ratingAgg =
+                mock(ReviewRepository.ActivityRatingAggregate.class);
+        when(ratingAgg.getAvgRating()).thenReturn(4.6);
+        when(ratingAgg.getReviewCount()).thenReturn(11L);
+
+        var dto = ActivityDtoMapper.toSummaryDto(activity, sessionAgg, ratingAgg);
+
+        assertThat(dto.price()).isEqualByComparingTo("1200.00");
+        assertThat(dto.availableSpots()).isEqualTo(8);
+        assertThat(dto.avgRating()).isEqualTo(4.6);
+        assertThat(dto.reviewCount()).isEqualTo(11L);
+        assertThat(dto.destination().name()).isEqualTo("Ushuaia");
+    }
+
+    @Test
+    void toSummaryDto_withoutRatingAggregate_defaultsToNullAndZero() {
+        ActivityEntity activity = new ActivityEntity();
+        activity.setId(8L);
+        activity.setName("Walking Tour");
+        activity.setCategory(ActivityCategory.FREE_TOUR);
+        activity.setDurationMinutes(60);
+        activity.setBasePrice(new BigDecimal("0.00"));
+        activity.setCurrency("ARS");
+
+        DestinationEntity destination = new DestinationEntity();
+        destination.setId(4L);
+        destination.setName("CABA");
+        activity.setDestination(destination);
+
+        var dto = ActivityDtoMapper.toSummaryDto(activity, null, null);
+
+        assertThat(dto.price()).isEqualByComparingTo("0.00");
+        assertThat(dto.availableSpots()).isZero();
+        assertThat(dto.avgRating()).isNull();
+        assertThat(dto.reviewCount()).isZero();
+    }
+}

--- a/src/test/java/com/example/desabackend/service/RecommendationServiceTest.java
+++ b/src/test/java/com/example/desabackend/service/RecommendationServiceTest.java
@@ -1,0 +1,96 @@
+package com.example.desabackend.service;
+
+import com.example.desabackend.entity.ActivityCategory;
+import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.entity.DestinationEntity;
+import com.example.desabackend.repository.ActivityRepository;
+import com.example.desabackend.repository.ActivitySessionRepository;
+import com.example.desabackend.repository.ReviewRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationServiceTest {
+
+    @Mock
+    private ActivityRepository activityRepository;
+    @Mock
+    private ActivitySessionRepository sessionRepository;
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private UserPreferenceService userPreferenceService;
+
+    private RecommendationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RecommendationService(activityRepository, sessionRepository, reviewRepository, userPreferenceService);
+    }
+
+    @Test
+    void listRecommended_includesAverageRatingAndReviewCountInSummary() {
+        ActivityEntity activity = new ActivityEntity();
+        activity.setId(5L);
+        activity.setName("Wine Tour");
+        activity.setCategory(ActivityCategory.GASTRONOMIA);
+        activity.setDurationMinutes(180);
+        activity.setBasePrice(new BigDecimal("35000.00"));
+        activity.setCurrency("ARS");
+
+        DestinationEntity destination = new DestinationEntity();
+        destination.setId(2L);
+        destination.setName("Mendoza");
+        activity.setDestination(destination);
+        ActivitySessionRepository.ActivitySummaryAggregate sessionAgg =
+            sessionAggregate(5L, 4L, new BigDecimal("32000.00"));
+        ReviewRepository.ActivityRatingAggregate ratingAgg = ratingAggregate(5L, 4.2, 6L);
+
+        when(userPreferenceService.getPreferredDestinationIds(99L)).thenReturn(List.of(2L));
+        when(userPreferenceService.getPreferredCategories(99L)).thenReturn(List.of(ActivityCategory.GASTRONOMIA));
+        when(activityRepository.findRecommended(any(), any(), eq(false), any(), any(), eq(false), eq(false), any(LocalDateTime.class), any()))
+                .thenReturn(new PageImpl<>(List.of(activity)));
+        when(sessionRepository.aggregateForNextSession(eq(List.of(5L)), any(LocalDateTime.class)))
+            .thenReturn(List.of(sessionAgg));
+        when(reviewRepository.aggregateActivityRatings(eq(List.of(5L))))
+            .thenReturn(List.of(ratingAgg));
+
+        var result = service.listRecommended(99L, 0, 10, null, null);
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).avgRating()).isEqualTo(4.2);
+        assertThat(result.items().get(0).reviewCount()).isEqualTo(6L);
+        assertThat(result.items().get(0).price()).isEqualByComparingTo("32000.00");
+    }
+
+    private static ActivitySessionRepository.ActivitySummaryAggregate sessionAggregate(
+            Long activityId, Long availableSpots, BigDecimal price) {
+        ActivitySessionRepository.ActivitySummaryAggregate aggregate =
+                mock(ActivitySessionRepository.ActivitySummaryAggregate.class);
+        when(aggregate.getActivityId()).thenReturn(activityId);
+        when(aggregate.getAvailableSpots()).thenReturn(availableSpots);
+        when(aggregate.getPrice()).thenReturn(price);
+        return aggregate;
+    }
+
+    private static ReviewRepository.ActivityRatingAggregate ratingAggregate(Long activityId, Double avgRating, Long reviewCount) {
+        ReviewRepository.ActivityRatingAggregate aggregate = mock(ReviewRepository.ActivityRatingAggregate.class);
+        when(aggregate.getActivityId()).thenReturn(activityId);
+        when(aggregate.getAvgRating()).thenReturn(avgRating);
+        when(aggregate.getReviewCount()).thenReturn(reviewCount);
+        return aggregate;
+    }
+}


### PR DESCRIPTION
Agrega avgRating y reviewCount a las respuestas de catálogo de actividades (listado/featured/recommended) y al detalle (/activities/{id}), calculándolos desde la tabla reviews para que el front pueda mostrar el rating promedio real.