### PR TITLE
Google Maps SDK implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ spring.sql.init.mode=always
 sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -d desa_db -i src/main/resources/data.sql
 ```
 
+### Seed de itinerarios (Feature 10)
+
+Para cargar puntos de itinerario (punto 27) en una DB ya existente:
+
+```bash
+sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -d desa_db -i scripts/seed_itinerary.sql
+```
+
 **Usuarios de prueba** (password: `123456`):
 - `test@example.com` (id=1)
 - `maria@example.com` (id=2)

--- a/scripts/seed_itinerary.sql
+++ b/scripts/seed_itinerary.sql
@@ -1,0 +1,29 @@
+-- Seed de itinerarios (Feature 10 - Punto 27)
+-- Ejecutar contra una DB existente:
+--   sqlcmd -S localhost -U sa -P "YourStrong!Passw0rd" -d desa_db -i scripts/seed_itinerary.sql
+
+IF OBJECT_ID('activity_itinerary_points', 'U') IS NULL
+BEGIN
+    PRINT 'Tabla activity_itinerary_points no existe. Levantar la app para que JPA la cree (ddl-auto=update).';
+    RETURN;
+END
+
+-- Activity 1 - Free Tour por San Telmo
+IF NOT EXISTS (SELECT 1 FROM activity_itinerary_points WHERE activity_id = 1)
+BEGIN
+    INSERT INTO activity_itinerary_points (activity_id, position, name, address) VALUES
+      (1, 1, 'Plaza Dorrego', 'Plaza Dorrego, San Telmo, Buenos Aires'),
+      (1, 2, 'Mercado de San Telmo', 'Mercado de San Telmo, Bolivar 970, Buenos Aires'),
+      (1, 3, 'Calle Defensa', 'Defensa, San Telmo, Buenos Aires');
+END
+
+-- Activity 4 - Excursion Alta Montana
+IF NOT EXISTS (SELECT 1 FROM activity_itinerary_points WHERE activity_id = 4)
+BEGIN
+    INSERT INTO activity_itinerary_points (activity_id, position, name, address) VALUES
+      (4, 1, 'Villavicencio', 'Villavicencio, Mendoza'),
+      (4, 2, 'Uspallata', 'Uspallata, Mendoza'),
+      (4, 3, 'Puente del Inca', 'Puente del Inca, Mendoza'),
+      (4, 4, 'Mirador del Aconcagua', 'Parque Provincial Aconcagua, Mendoza');
+END
+

--- a/src/main/java/com/example/desabackend/dto/ActivityDetailDto.java
+++ b/src/main/java/com/example/desabackend/dto/ActivityDetailDto.java
@@ -16,6 +16,7 @@ public record ActivityDetailDto(
         String description,
         String includesText,
         String meetingPoint,
+        List<ItineraryPointDto> itineraryPoints,
         GuideDto guide,
         int durationMinutes,
         String language,

--- a/src/main/java/com/example/desabackend/dto/ItineraryPointDto.java
+++ b/src/main/java/com/example/desabackend/dto/ItineraryPointDto.java
@@ -1,0 +1,9 @@
+package com.example.desabackend.dto;
+
+public record ItineraryPointDto(
+        String name,
+        String address,
+        int position
+) {
+}
+

--- a/src/main/java/com/example/desabackend/entity/ActivityEntity.java
+++ b/src/main/java/com/example/desabackend/entity/ActivityEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -80,4 +81,8 @@ public class ActivityEntity {
 
     @OneToMany(mappedBy = "activity", fetch = FetchType.LAZY)
     private List<ActivitySessionEntity> sessions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "activity", fetch = FetchType.LAZY)
+    @OrderBy("position ASC")
+    private List<ActivityItineraryPointEntity> itineraryPoints = new ArrayList<>();
 }

--- a/src/main/java/com/example/desabackend/entity/ActivityItineraryPointEntity.java
+++ b/src/main/java/com/example/desabackend/entity/ActivityItineraryPointEntity.java
@@ -1,0 +1,40 @@
+package com.example.desabackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "activity_itinerary_points")
+public class ActivityItineraryPointEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private ActivityEntity activity;
+
+    @Column(nullable = false)
+    private Integer position;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(length = 300)
+    private String address;
+}
+

--- a/src/main/java/com/example/desabackend/service/ActivityCatalogService.java
+++ b/src/main/java/com/example/desabackend/service/ActivityCatalogService.java
@@ -3,6 +3,7 @@ package com.example.desabackend.service;
 import com.example.desabackend.dto.ActivityDetailDto;
 import com.example.desabackend.dto.ActivitySessionDto;
 import com.example.desabackend.dto.ActivitySummaryDto;
+import com.example.desabackend.dto.ItineraryPointDto;
 import com.example.desabackend.dto.PageResponse;
 import com.example.desabackend.entity.ActivityCategory;
 import com.example.desabackend.entity.ActivityEntity;
@@ -15,6 +16,7 @@ import com.example.desabackend.repository.FavoriteRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -126,6 +128,17 @@ public class ActivityCatalogService {
 
         boolean isFavorite = userId != null && favoriteRepository.existsByUserIdAndActivityId(userId, activityId);
 
+        List<ItineraryPointDto> itineraryPoints = activity.getItineraryPoints() == null
+                ? List.of()
+                : activity.getItineraryPoints().stream()
+                        .sorted(Comparator.comparingInt(p -> p.getPosition() != null ? p.getPosition() : 0))
+                        .map(p -> new ItineraryPointDto(
+                                p.getName(),
+                                p.getAddress(),
+                                p.getPosition() != null ? p.getPosition() : 0
+                        ))
+                        .toList();
+
         return new ActivityDetailDto(
                 activity.getId(),
                 activity.getName(),
@@ -135,6 +148,7 @@ public class ActivityCatalogService {
                 activity.getDescription(),
                 activity.getIncludesText(),
                 activity.getMeetingPoint(),
+                itineraryPoints,
                 ActivityDtoMapper.toGuideDto(activity),
                 ActivityDtoMapper.nonNullInt(activity.getDurationMinutes()),
                 activity.getLanguage(),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -137,3 +137,18 @@ INSERT INTO reviews (id, booking_id, user_id, activity_id, guide_id, activity_ra
 INSERT INTO reviews (id, booking_id, user_id, activity_id, guide_id, activity_rating, guide_rating, comment, created_at) VALUES (5, 9, 2, 1, 1, 4, 4, 'Lindo paseo, el barrio tiene mucha historia.', '2026-04-01 15:00:00');
 INSERT INTO reviews (id, booking_id, user_id, activity_id, guide_id, activity_rating, guide_rating, comment, created_at) VALUES (6, 10, 2, 8, 2, 5, 5, 'Espectacular! La Garganta del Diablo te deja sin palabras.', '2026-04-01 17:00:00');
 SET IDENTITY_INSERT reviews OFF;
+
+-- =========================================================
+-- Itinerarios (Punto 27 - Feature 10)
+-- Nota: requiere la tabla activity_itinerary_points (JPA ddl-auto=update)
+-- =========================================================
+INSERT INTO activity_itinerary_points (activity_id, position, name, address) VALUES
+  (1, 1, 'Plaza Dorrego', 'Plaza Dorrego, San Telmo, Buenos Aires'),
+  (1, 2, 'Mercado de San Telmo', 'Mercado de San Telmo, Bolivar 970, Buenos Aires'),
+  (1, 3, 'Calle Defensa', 'Defensa, San Telmo, Buenos Aires');
+
+INSERT INTO activity_itinerary_points (activity_id, position, name, address) VALUES
+  (4, 1, 'Villavicencio', 'Villavicencio, Mendoza'),
+  (4, 2, 'Uspallata', 'Uspallata, Mendoza'),
+  (4, 3, 'Puente del Inca', 'Puente del Inca, Mendoza'),
+  (4, 4, 'Mirador del Aconcagua', 'Parque Provincial Aconcagua, Mendoza');

--- a/src/test/java/com/example/desabackend/service/ActivityCatalogServiceTest.java
+++ b/src/test/java/com/example/desabackend/service/ActivityCatalogServiceTest.java
@@ -2,6 +2,7 @@ package com.example.desabackend.service;
 
 import com.example.desabackend.entity.ActivityCategory;
 import com.example.desabackend.entity.ActivityEntity;
+import com.example.desabackend.entity.ActivityItineraryPointEntity;
 import com.example.desabackend.entity.ActivitySessionEntity;
 import com.example.desabackend.entity.DestinationEntity;
 import com.example.desabackend.entity.GuideEntity;
@@ -11,6 +12,7 @@ import com.example.desabackend.repository.FavoriteRepository;
 import com.example.desabackend.repository.ReviewRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,6 +97,31 @@ class ActivityCatalogServiceTest {
         assertThat(result.sessions()).hasSize(1);
     }
 
+    @Test
+    void getActivityDetail_includesItineraryPointsSortedByPosition() {
+        ActivityEntity activity = createActivity(3L, "Recorrido");
+        activity.setMeetingPoint("Plaza Dorrego");
+
+        List<ActivityItineraryPointEntity> points = new ArrayList<>();
+        points.add(itineraryPoint(activity, 2, "Mercado de San Telmo"));
+        points.add(itineraryPoint(activity, 1, "Plaza Dorrego"));
+        activity.setItineraryPoints(points);
+
+        when(activityRepository.findById(3L)).thenReturn(Optional.of(activity));
+        when(sessionRepository.findFutureByActivityId(eq(3L), any(LocalDateTime.class)))
+                .thenReturn(List.of());
+        when(reviewRepository.getActivityRating(3L)).thenReturn(Optional.empty());
+        when(favoriteRepository.existsByUserIdAndActivityId(77L, 3L)).thenReturn(false);
+
+        var result = service.getActivityDetail(3L, null, 77L);
+
+        assertThat(result.itineraryPoints()).hasSize(2);
+        assertThat(result.itineraryPoints().get(0).position()).isEqualTo(1);
+        assertThat(result.itineraryPoints().get(0).name()).isEqualTo("Plaza Dorrego");
+        assertThat(result.itineraryPoints().get(1).position()).isEqualTo(2);
+        assertThat(result.itineraryPoints().get(1).name()).isEqualTo("Mercado de San Telmo");
+    }
+
     private static ActivityEntity createActivity(Long id, String name) {
         ActivityEntity activity = new ActivityEntity();
         activity.setId(id);
@@ -119,6 +146,15 @@ class ActivityCatalogServiceTest {
         guide.setFullName("Ana Guide");
         activity.setGuide(guide);
         return activity;
+    }
+
+    private static ActivityItineraryPointEntity itineraryPoint(ActivityEntity activity, int position, String name) {
+        ActivityItineraryPointEntity point = new ActivityItineraryPointEntity();
+        point.setActivity(activity);
+        point.setPosition(position);
+        point.setName(name);
+        point.setAddress(name);
+        return point;
     }
 
     private static ActivitySessionRepository.ActivitySummaryAggregate sessionAggregate(


### PR DESCRIPTION
Agrega soporte de itinerarios para cumplir el punto 27:

El endpoint de detalle de actividad ahora devuelve una lista ordenada de “puntos del itinerario” (si la actividad tiene recorrido).
Se incluye un seed para cargar ejemplos de itinerario en la base local.
Requisitos para que funcione localmente:

Levantar el backend (ideal con docker compose up --build -d) para que Hibernate cree la tabla nueva.
Ejecutar el seed una vez para cargar puntos de ejemplo:
scripts/seed_itinerary.sql (el README del backend ya incluye el comando sugerido).